### PR TITLE
Fix wrong casting for $Body.

### DIFF
--- a/Invoke-AkamaiOPEN.ps1
+++ b/Invoke-AkamaiOPEN.ps1
@@ -41,7 +41,7 @@ Invoke-AkamaiOPEN -Method GET -ClientToken "foo" -ClientAccessToken "foo" -Clien
 developer.akamai.com
 #>
 
-param([Parameter(Mandatory=$true)][string]$Method, [Parameter(Mandatory=$true)][string]$ClientToken, [Parameter(Mandatory=$true)][string]$ClientAccessToken, [Parameter(Mandatory=$true)][string]$ClientSecret, [Parameter(Mandatory=$true)][string]$ReqURL, [Parameter][object]$Body)
+param([Parameter(Mandatory=$true)][string]$Method, [Parameter(Mandatory=$true)][string]$ClientToken, [Parameter(Mandatory=$true)][string]$ClientAccessToken, [Parameter(Mandatory=$true)][string]$ClientSecret, [Parameter(Mandatory=$true)][string]$ReqURL, [Parameter(Mandatory=$true)][object]$Body)
 
 #Function to generate HMAC SHA256 Base64
 Function Crypto ($secret, $message)


### PR DESCRIPTION
By omitting the (Mandatory=$true) from the parameter definition, the
$body object was being casted to a
System.Management.Automation.ParameterAttribute object.
Issue link: https://github.com/akamai-open/AkamaiOPEN-powershell/issues/1