### PR TITLE
Correct issues with POST and PUT

### DIFF
--- a/Invoke-AkamaiOPEN.ps1
+++ b/Invoke-AkamaiOPEN.ps1
@@ -119,24 +119,19 @@ $Headers.Add('Authorization',$AuthorizationHeader)
 If (($Method -ceq "POST") -or ($Method -ceq "PUT"))
 {
 	$Body_Size = [System.Text.Encoding]::UTF8.GetByteCount($Body)
-	$Headers.Add('max-body',$Body_Size)
-	$Headers.Add('Content-Type','application/json')
+	$Headers.Add('max-body',$Body_Size.ToString())
 }
 
 #Check for valid Methods and required switches
 If (($Method -ceq "POST") -and ($Body -ne $null))
 {
 	#Invoke API call with POST and return
-	$ErrorActionPreference = 'SilentlyContinue'
-	Invoke-RestMethod -Method $Method -Uri $ReqURL -SessionVariable api
-	$api.Headers.set_Item('Expect', '')
-	$ErrorActionPreference = 'Continue'
-	Invoke-RestMethod -Method $Method -WebSession $api -Uri $ReqURL -Headers $Headers -Body $Body
+	Invoke-RestMethod -Method $Method -WebSession $api -Uri $ReqURL -Headers $Headers -Body $Body -ContentType 'application/json'
 }
 elseif  (($Method -ceq "PUT") -and ($Body -ne $null))
 {
 	#Invoke API call with PUT and return
-	Invoke-RestMethod -Method $Method -Uri $ReqURL -Headers $Headers -Body $Body
+	Invoke-RestMethod -Method $Method -Uri $ReqURL -Headers $Headers -Body $Body -ContentType 'application/json'
 }
 elseif (($Method -ceq "GET") -or ($Method -ceq "DELETE"))
 {


### PR DESCRIPTION
This pull request fixes multiple issues preventing POST and PUT from succeeding:

The line `$Headers.Add('max-body',$Body_Size)` was causing `Invoke-RestMethod` to fail with an `InvalidCastException`.  Changing the value to `$Body_Size.ToString()` resolves this issue.

`$Headers.Add('Content-Type','application/json')` is not supported with `Invoke-RestMethod`.  Instead, the `-ContentType` parameter is passed.

Also, I do not understand why there were multiple POSTs happening (one with no body, then one with a body).  The 1st post failed for me always, and removing it corrected the issue.