### PR TITLE
Fix post requests

### DIFF
--- a/Invoke-AkamaiOPEN.ps1
+++ b/Invoke-AkamaiOPEN.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 3.0
 <#
   Copyright 2013 Akamai Technologies, Inc. All Rights Reserved.
 
@@ -120,25 +121,16 @@ If (($Method -ceq "POST") -or ($Method -ceq "PUT"))
 {
 	$Body_Size = [System.Text.Encoding]::UTF8.GetByteCount($Body)
 	$Headers.Add('max-body',$Body_Size.ToString())
+
+    # turn off the "Expect: 100 Continue" header
+    # as it's not supported on the Akamai side.
+    [System.Net.ServicePointManager]::Expect100Continue = $false
 }
 
 #Check for valid Methods and required switches
 If (($Method -ceq "POST") -and ($Body -ne $null))
 {
-  #Invoke API call with POST and return
-  try 
-  {
-    Invoke-RestMethod -Method $Method -Uri $ReqURL -SessionVariable api -ErrorAction Stop
-  }
-  catch 
-  {
-    # do nothing / suppress error output.
-    # would like to find a better way to get rid of the header vs making the bad request.
-  }
-  
-  #Whack Expect: 100-continue header which OPEN does not support
-  $api.Headers.set_Item('Expect', '')
-  Invoke-RestMethod -Method $Method -WebSession $api -Uri $ReqURL -Headers $Headers -Body $Body -ContentType 'application/json'
+    Invoke-RestMethod -Method $Method -Uri $ReqURL -Headers $Headers -Body $Body -ContentType 'application/json'
 }
 elseif  (($Method -ceq "PUT") -and ($Body -ne $null))
 {

--- a/Invoke-AkamaiOPEN.ps1
+++ b/Invoke-AkamaiOPEN.ps1
@@ -126,12 +126,19 @@ If (($Method -ceq "POST") -or ($Method -ceq "PUT"))
 If (($Method -ceq "POST") -and ($Body -ne $null))
 {
   #Invoke API call with POST and return
-  $ErrorActionPreference = 'SilentlyContinue'
-  Invoke-RestMethod -Method $Method -Uri $ReqURL -SessionVariable api
+  try 
+  {
+    Invoke-RestMethod -Method $Method -Uri $ReqURL -SessionVariable api -ErrorAction Stop
+  }
+  catch 
+  {
+    # do nothing / suppress error output.
+    # would like to find a better way to get rid of the header vs making the bad request.
+  }
+  
   #Whack Expect: 100-continue header which OPEN does not support
   $api.Headers.set_Item('Expect', '')
-  $ErrorActionPreference = 'Continue'
-	Invoke-RestMethod -Method $Method -WebSession $api -Uri $ReqURL -Headers $Headers -Body $Body -ContentType 'application/json'
+  Invoke-RestMethod -Method $Method -WebSession $api -Uri $ReqURL -Headers $Headers -Body $Body -ContentType 'application/json'
 }
 elseif  (($Method -ceq "PUT") -and ($Body -ne $null))
 {


### PR DESCRIPTION
I originally started on this because the initial / sacrificial Invoke-RestMethod call  on line 130 was bubbling up when I wrapped Invoke-Akamai.ps1 in a try/catch block in a parent script.

At first I just wrapped the first call in a try/catch block to fully suppress the error, but eventually I figured out how to just turn the header off, eliminating the need for sending two requests while posting.

As an aside, the original approach seemed to work even if I didn't set or do anything with the $api variable. I'm guessing that Invoke-Restmethod must be doing something to that .Net property when certain conditions are met, but didn't run it all the way to ground.